### PR TITLE
Implement upcoming matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ h.GetUpcomingMatches([]int{7532,8637})  // Filtered by team IDs
 ```
 <details><summary>Output</summary>
 <p>	
+
 ```json
 [
     {

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ func main() {
 	* [GetPlayer](#getplayer)
 	* [GetPlayerByName](#getplayerbynamename)
 	* [GetPlayerStats](#getplayerstats)
+	* [GetUpcomingMatches](#getupcomingmatches)
 	    
 
 #### GetPlayer
@@ -651,5 +652,37 @@ h.GetPlayerStats(7998, hltv.PlayerStatsQuery{
 }
 ```
 
+</p>
+</details>
+
+#### GetUpcomingMatches
+
+```golang
+//GetUpcomingMatches(teamIDs []int) (upcomingMatches []*model.UpcomingMatch, err error)
+h.GetUpcomingMatches(nil)  // All matches
+h.GetUpcomingMatches([]int{7532,8637})  // Filtered by team IDs
+```
+<details><summary>Output</summary>
+<p>	
+```json
+[
+    {
+        "ID": 2339374,
+        "Team1": {
+            "Name": "Astralis",
+            "ID": 6665
+        },
+        "Team2": {
+            "Name": "Cloud9",
+            "ID": 5752
+        },
+        "Date": "2020-02-24T12:00:00+01:00",
+        "Event": {
+            "Name": "IEM Katowice 2020",
+            "ID": 4901
+        }
+    }
+]
+```
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -658,9 +658,11 @@ h.GetPlayerStats(7998, hltv.PlayerStatsQuery{
 #### GetUpcomingMatches
 
 ```golang
-//GetUpcomingMatches(teamIDs []int) (upcomingMatches []*model.UpcomingMatch, err error)
-h.GetUpcomingMatches(nil)  // All matches
-h.GetUpcomingMatches([]int{7532,8637})  // Filtered by team IDs
+//GetUpcomingMatches(UpcomingMatchesQuery{}) (upcomingMatches []*model.UpcomingMatch, err error)
+h.GetUpcomingMatches(UpcomingMatchesQuery{})  // All matches
+h.GetUpcomingMatches(UpcomingMatchesQuery{  // Filtered by team IDs
+  		Team: []int{7532,8637},
+})
 ```
 <details><summary>Output</summary>
 <p>	

--- a/model/upcoming_match.go
+++ b/model/upcoming_match.go
@@ -1,0 +1,11 @@
+package model
+
+import "time"
+
+type UpcomingMatch struct {
+	ID    *int
+	Team1 Team
+	Team2 Team
+	Date  time.Time
+	Event Event
+}

--- a/upcoming_matches.go
+++ b/upcoming_matches.go
@@ -1,27 +1,24 @@
 package hltv
 
 import (
-	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/google/go-querystring/query"
 
 	"github.com/Olament/HLTV-Go/model"
 	"github.com/Olament/HLTV-Go/utils"
 )
 
-func (h *HLTV) GetUpcomingMatches(teamIDs []int) (upcomingMatches []*model.UpcomingMatch, err error) {
+type UpcomingMatchesQuery struct {
+	Team []int
+}
+
+func (h *HLTV) GetUpcomingMatches(q UpcomingMatchesQuery) (upcomingMatches []*model.UpcomingMatch, err error) {
 	// Build query string parameters
-	queryString := ""
-	if len(teamIDs) > 0 {
-		q := url.Values{}
-		for _, teamID := range teamIDs {
-			q.Add("team", strconv.Itoa(teamID))
-		}
-		queryString = q.Encode()
-	}
-	res, err := utils.GetQuery(h.Url + "/matches/?" + queryString)
+	queryString, _ := query.Values(q)
+	res, err := utils.GetQuery(h.Url + "/matches/?" + queryString.Encode())
 	defer res.Body.Close()
 	if err != nil {
 		return nil, err

--- a/upcoming_matches.go
+++ b/upcoming_matches.go
@@ -1,0 +1,70 @@
+package hltv
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"github.com/Olament/HLTV-Go/model"
+	"github.com/Olament/HLTV-Go/utils"
+)
+
+func (h *HLTV) GetUpcomingMatches(teamIDs []int) (upcomingMatches []*model.UpcomingMatch, err error) {
+	// Build query string parameters
+	queryString := ""
+	if len(teamIDs) > 0 {
+		q := url.Values{}
+		for _, teamID := range teamIDs {
+			q.Add("team", strconv.Itoa(teamID))
+		}
+		queryString = q.Encode()
+	}
+	res, err := utils.GetQuery(h.Url + "/matches/?" + queryString)
+	defer res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	doc.Find(".upcoming-match").Each(func(i int, selection *goquery.Selection) {
+		matchHref, _ := selection.Find(".a-reset").First().Attr("href")
+		matchID, _ := strconv.Atoi(strings.Split(matchHref, "/")[2])
+		matchTimestamp, _ := selection.Find("div.time").First().Attr("data-unix")
+		date := utils.UnixTimeStringToTime(matchTimestamp)
+
+		eventName, _ := selection.Find(".event-logo").Attr("alt")
+		eventID, _ := strconv.Atoi(strings.Split(utils.PopSlashSource(selection.Find("img.event-logo")), ".")[0])
+
+		team1Name := selection.Find("div.team").First().Text()
+		team1ID, _ := strconv.Atoi(utils.PopSlashSource(selection.Find("img.logo").First()))
+
+		team2Name := selection.Find("div.team").Last().Text()
+		team2ID, _ := strconv.Atoi(utils.PopSlashSource(selection.Find("img.logo").Last()))
+
+		match := &model.UpcomingMatch{
+			ID: &matchID,
+			Team1: model.Team{
+				Name: team1Name,
+				ID:   &team1ID,
+			},
+			Team2: model.Team{
+				Name: team2Name,
+				ID:   &team2ID,
+			},
+			Date: date,
+			Event: model.Event{
+				Name: eventName,
+				ID:   &eventID,
+			},
+		}
+		upcomingMatches = append(upcomingMatches, match)
+	})
+
+	return upcomingMatches, nil
+}

--- a/upcoming_matches_test.go
+++ b/upcoming_matches_test.go
@@ -1,0 +1,43 @@
+package hltv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpcomingMatches(t *testing.T) {
+	h := HLTV{
+		Url:       "https://www.hltv.org",
+		StaticURL: "",
+	}
+
+	matches, err := h.GetUpcomingMatches(nil)
+	if err != nil {
+		t.Errorf("GetUpcomingMatches returned an error %v", err)
+		return
+	}
+	if len(matches) == 0 {
+		t.Errorf("GetUpcomingMatches returned no matches")
+		return
+	}
+
+	m := matches[0]
+	if *m.ID == 0 {
+		t.Errorf("Matches have no ID")
+	}
+	if m.Date == time.Unix(0, 0) {
+		t.Errorf("Match has wrong date")
+	}
+	if m.Team1.Name == "" {
+		t.Errorf("Teams have no name")
+	}
+	if *m.Team1.ID == 0 {
+		t.Errorf("Teams have no ID")
+	}
+	if m.Event.Name == "" {
+		t.Errorf("Events have no Name")
+	}
+	if *m.Event.ID == 0 {
+		t.Errorf("Events have no ID")
+	}
+}

--- a/upcoming_matches_test.go
+++ b/upcoming_matches_test.go
@@ -11,7 +11,7 @@ func TestUpcomingMatches(t *testing.T) {
 		StaticURL: "",
 	}
 
-	matches, err := h.GetUpcomingMatches(nil)
+	matches, err := h.GetUpcomingMatches(UpcomingMatchesQuery{})
 	if err != nil {
 		t.Errorf("GetUpcomingMatches returned an error %v", err)
 		return


### PR DESCRIPTION
This PR adds a new function to the API for getting upcoming matches.
It even has a feature that the node package is lacking: Filtering for teams

I also added tests for the new features; might be a good idea to add it to the other functions.