### PR TITLE
Add match format to upcoming match

### DIFF
--- a/model/upcoming_match.go
+++ b/model/upcoming_match.go
@@ -3,9 +3,10 @@ package model
 import "time"
 
 type UpcomingMatch struct {
-	ID    *int
-	Team1 Team
-	Team2 Team
-	Date  time.Time
-	Event Event
+	ID     *int
+	Team1  Team
+	Team2  Team
+	Date   time.Time
+	Event  Event
+	Format string
 }

--- a/upcoming_matches.go
+++ b/upcoming_matches.go
@@ -44,6 +44,8 @@ func (h *HLTV) GetUpcomingMatches(q UpcomingMatchesQuery) (upcomingMatches []*mo
 		team2Name := selection.Find("div.team").Last().Text()
 		team2ID, _ := strconv.Atoi(utils.PopSlashSource(selection.Find("img.logo").Last()))
 
+		format := selection.Find("div.map-text").Last().Text()
+
 		match := &model.UpcomingMatch{
 			ID: &matchID,
 			Team1: model.Team{
@@ -59,6 +61,7 @@ func (h *HLTV) GetUpcomingMatches(q UpcomingMatchesQuery) (upcomingMatches []*mo
 				Name: eventName,
 				ID:   &eventID,
 			},
+			Format: format,
 		}
 		upcomingMatches = append(upcomingMatches, match)
 	})

--- a/upcoming_matches_test.go
+++ b/upcoming_matches_test.go
@@ -1,6 +1,7 @@
 package hltv
 
 import (
+	"regexp"
 	"testing"
 	"time"
 )
@@ -39,5 +40,12 @@ func TestUpcomingMatches(t *testing.T) {
 	}
 	if *m.Event.ID == 0 {
 		t.Errorf("Events have no ID")
+	}
+	if m.Format == "" {
+		t.Errorf("Match format is not defined")
+	}
+	formatMatched, _ := regexp.MatchString(`^bo\d{1}$`, m.Format)
+	if !formatMatched {
+		t.Errorf("Unexpected match format string")
 	}
 }


### PR DESCRIPTION
This adds the format of a match (`bo1`, `bo3`, `bo5`) to the upcoming match.

Please also create a new release, once this is merged :blush: 